### PR TITLE
Add `g++` install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The dependency to GConf can be removed by passing `-DENABLE_GCONF_MIGRATION=OFF`
 ### Ubuntu-specific packages
 All the dependencies on an Ubuntu system can be installed with:
 ```
-sudo apt install cmake libgconf2-dev libxml2-dev libgtk-3-dev libgstreamer1.0-dev libnotify-dev libayatana-appindicator3-dev gettext gnome-icon-theme
+sudo apt install cmake libgconf2-dev libxml2-dev libgtk-3-dev libgstreamer1.0-dev libnotify-dev libayatana-appindicator3-dev gettext gnome-icon-theme g++
 ```
 
 ## Installation


### PR DESCRIPTION
。You need to install g++ to be able to compile locally, otherwise the following error will be reported

```sh
> cmake .. -DCMAKE_BUILD_TYPE=Release

-- The C compiler identification is GNU 11.3.0
-- The CXX compiler identification is unknown
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error at CMakeLists.txt:4 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.


-- Configuring incomplete, errors occurred!
See also "/home/bear/working/alarm-clock/build/CMakeFiles/CMakeOutput.log".
See also "/home/bear/working/alarm-clock/build/CMakeFiles/CMakeError.log".

```